### PR TITLE
Update `parse` function signature in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ All available options with default values are listed below:
 
 ```kotlin
 val kspoon = Kspoon {
-    // Specifies the Ksoup function used for parsing. Type: Ksoup.(String) -> Document
-    parse = { html: String -> parse(html) }
+    // Specifies the parsing function. Type: (String) -> Document
+    parse = { html: String -> Ksoup.parse(html, baseUri = "") }
     // Default text mode used for parsing.
     defaultTextMode = HtmlTextMode.Text
     // Enables coercing values when the selected HTML element is not found.

--- a/docs/ktor.md
+++ b/docs/ktor.md
@@ -18,8 +18,9 @@ dependencies {
 Install Ktor content negotiation plugin on `HttpClient` and register `KotlinxSerializationConverter` with `Kspoon.toFormat()` for HTML content type:
 
 ```kotlin
+val baseUrl = "https://github.com/"
 val kspoon = Kspoon {
-    // Configure Kspoon
+    parse = { html -> Ksoup.parse(html, baseUri = baseUrl) }
 }
 val client = HttpClient {
     install(ContentNegotiation) {
@@ -39,6 +40,6 @@ data class GithubProfile(
     val avatarUrl: String,
 )
 
-val profile = client.get<Page>("https://github.com/burnoo").body()
+val profile = client.get<Page>("${baseUrl}burnoo").body()
 println(profile) // GithubProfile(displayName=burnoo (Bruno Wieczorek), avatarUrl=https://avatars.githubusercontent.com/u/17478192?v=4)
 ```

--- a/docs/retrofit.md
+++ b/docs/retrofit.md
@@ -17,15 +17,16 @@ dependencies {
 Add `ConverterFactory` to your `Retrofit` instance. Use `asConverterFactory()` extension function on `Ksoup.toFormat()`:
 
 ```kotlin
+val baseUrl = "https://github.com/"
 val kspoon = Kspoon {
-    // Configure Kspoon
+    parse = { html -> Ksooup.parse(html, baseUri = baseUrl) }
 }
 
 val retrofit = Retrofit.Builder()
     .addConverterFactory(
         kspoon.toFormat().asConverterFactory("text/html; charset=UTF8".toMediaType())
     )
-    .baseUrl("https://github.com/")
+    .baseUrl(baseUrl)
     .build()
 ```
 

--- a/example/src/main/kotlin/SimpleExample.kt
+++ b/example/src/main/kotlin/SimpleExample.kt
@@ -1,4 +1,4 @@
-
+import com.fleeksoft.ksoup.Ksoup
 import dev.burnoo.kspoon.Kspoon
 import dev.burnoo.kspoon.annotation.Selector
 import kotlinx.serialization.Serializable
@@ -27,7 +27,7 @@ data class FakeGitHubProfile(
 
 fun simpleExample() {
     val kspoon = Kspoon {
-        parse = { html -> parse(html, baseUri = "https://github.com/") }
+        parse = { html -> Ksoup.parse(html, baseUri = "https://github.com/") }
         coerceInputValues = true
     }
 

--- a/kspoon/api/kspoon.api
+++ b/kspoon/api/kspoon.api
@@ -59,21 +59,21 @@ public synthetic class dev/burnoo/kspoon/annotation/Selector$Impl : dev/burnoo/k
 public final class dev/burnoo/kspoon/configuration/KspoonBuilder {
 	public final fun getCoerceInputValues ()Z
 	public final fun getDefaultTextMode ()Ldev/burnoo/kspoon/HtmlTextMode;
-	public final fun getParse ()Lkotlin/jvm/functions/Function2;
+	public final fun getParse ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 	public final fun setCoerceInputValues (Z)V
 	public final fun setDefaultTextMode (Ldev/burnoo/kspoon/HtmlTextMode;)V
-	public final fun setParse (Lkotlin/jvm/functions/Function2;)V
+	public final fun setParse (Lkotlin/jvm/functions/Function1;)V
 	public final fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
 }
 
 public final class dev/burnoo/kspoon/configuration/KspoonConfiguration {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function2;Ldev/burnoo/kspoon/HtmlTextMode;ZLkotlinx/serialization/modules/SerializersModule;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Ldev/burnoo/kspoon/HtmlTextMode;ZLkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Ldev/burnoo/kspoon/HtmlTextMode;ZLkotlinx/serialization/modules/SerializersModule;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ldev/burnoo/kspoon/HtmlTextMode;ZLkotlinx/serialization/modules/SerializersModule;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getCoerceInputValues ()Z
 	public final fun getDefaultTextMode ()Ldev/burnoo/kspoon/HtmlTextMode;
-	public final fun getParse ()Lkotlin/jvm/functions/Function2;
+	public final fun getParse ()Lkotlin/jvm/functions/Function1;
 	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
 }
 

--- a/kspoon/api/kspoon.klib.api
+++ b/kspoon/api/kspoon.klib.api
@@ -66,22 +66,22 @@ final class dev.burnoo.kspoon.configuration/KspoonBuilder { // dev.burnoo.kspoon
         final fun <get-defaultTextMode>(): dev.burnoo.kspoon/HtmlTextMode // dev.burnoo.kspoon.configuration/KspoonBuilder.defaultTextMode.<get-defaultTextMode>|<get-defaultTextMode>(){}[0]
         final fun <set-defaultTextMode>(dev.burnoo.kspoon/HtmlTextMode) // dev.burnoo.kspoon.configuration/KspoonBuilder.defaultTextMode.<set-defaultTextMode>|<set-defaultTextMode>(dev.burnoo.kspoon.HtmlTextMode){}[0]
     final var parse // dev.burnoo.kspoon.configuration/KspoonBuilder.parse|{}parse[0]
-        final fun <get-parse>(): kotlin/Function2<com.fleeksoft.ksoup/Ksoup, kotlin/String, com.fleeksoft.ksoup.nodes/Document> // dev.burnoo.kspoon.configuration/KspoonBuilder.parse.<get-parse>|<get-parse>(){}[0]
-        final fun <set-parse>(kotlin/Function2<com.fleeksoft.ksoup/Ksoup, kotlin/String, com.fleeksoft.ksoup.nodes/Document>) // dev.burnoo.kspoon.configuration/KspoonBuilder.parse.<set-parse>|<set-parse>(kotlin.Function2<com.fleeksoft.ksoup.Ksoup,kotlin.String,com.fleeksoft.ksoup.nodes.Document>){}[0]
+        final fun <get-parse>(): kotlin/Function1<kotlin/String, com.fleeksoft.ksoup.nodes/Document> // dev.burnoo.kspoon.configuration/KspoonBuilder.parse.<get-parse>|<get-parse>(){}[0]
+        final fun <set-parse>(kotlin/Function1<kotlin/String, com.fleeksoft.ksoup.nodes/Document>) // dev.burnoo.kspoon.configuration/KspoonBuilder.parse.<set-parse>|<set-parse>(kotlin.Function1<kotlin.String,com.fleeksoft.ksoup.nodes.Document>){}[0]
     final var serializersModule // dev.burnoo.kspoon.configuration/KspoonBuilder.serializersModule|{}serializersModule[0]
         final fun <get-serializersModule>(): kotlinx.serialization.modules/SerializersModule // dev.burnoo.kspoon.configuration/KspoonBuilder.serializersModule.<get-serializersModule>|<get-serializersModule>(){}[0]
         final fun <set-serializersModule>(kotlinx.serialization.modules/SerializersModule) // dev.burnoo.kspoon.configuration/KspoonBuilder.serializersModule.<set-serializersModule>|<set-serializersModule>(kotlinx.serialization.modules.SerializersModule){}[0]
 }
 
 final class dev.burnoo.kspoon.configuration/KspoonConfiguration { // dev.burnoo.kspoon.configuration/KspoonConfiguration|null[0]
-    constructor <init>(kotlin/Function2<com.fleeksoft.ksoup/Ksoup, kotlin/String, com.fleeksoft.ksoup.nodes/Document> = ..., dev.burnoo.kspoon/HtmlTextMode = ..., kotlin/Boolean = ..., kotlinx.serialization.modules/SerializersModule = ...) // dev.burnoo.kspoon.configuration/KspoonConfiguration.<init>|<init>(kotlin.Function2<com.fleeksoft.ksoup.Ksoup,kotlin.String,com.fleeksoft.ksoup.nodes.Document>;dev.burnoo.kspoon.HtmlTextMode;kotlin.Boolean;kotlinx.serialization.modules.SerializersModule){}[0]
+    constructor <init>(kotlin/Function1<kotlin/String, com.fleeksoft.ksoup.nodes/Document> = ..., dev.burnoo.kspoon/HtmlTextMode = ..., kotlin/Boolean = ..., kotlinx.serialization.modules/SerializersModule = ...) // dev.burnoo.kspoon.configuration/KspoonConfiguration.<init>|<init>(kotlin.Function1<kotlin.String,com.fleeksoft.ksoup.nodes.Document>;dev.burnoo.kspoon.HtmlTextMode;kotlin.Boolean;kotlinx.serialization.modules.SerializersModule){}[0]
 
     final val coerceInputValues // dev.burnoo.kspoon.configuration/KspoonConfiguration.coerceInputValues|{}coerceInputValues[0]
         final fun <get-coerceInputValues>(): kotlin/Boolean // dev.burnoo.kspoon.configuration/KspoonConfiguration.coerceInputValues.<get-coerceInputValues>|<get-coerceInputValues>(){}[0]
     final val defaultTextMode // dev.burnoo.kspoon.configuration/KspoonConfiguration.defaultTextMode|{}defaultTextMode[0]
         final fun <get-defaultTextMode>(): dev.burnoo.kspoon/HtmlTextMode // dev.burnoo.kspoon.configuration/KspoonConfiguration.defaultTextMode.<get-defaultTextMode>|<get-defaultTextMode>(){}[0]
     final val parse // dev.burnoo.kspoon.configuration/KspoonConfiguration.parse|{}parse[0]
-        final fun <get-parse>(): kotlin/Function2<com.fleeksoft.ksoup/Ksoup, kotlin/String, com.fleeksoft.ksoup.nodes/Document> // dev.burnoo.kspoon.configuration/KspoonConfiguration.parse.<get-parse>|<get-parse>(){}[0]
+        final fun <get-parse>(): kotlin/Function1<kotlin/String, com.fleeksoft.ksoup.nodes/Document> // dev.burnoo.kspoon.configuration/KspoonConfiguration.parse.<get-parse>|<get-parse>(){}[0]
     final val serializersModule // dev.burnoo.kspoon.configuration/KspoonConfiguration.serializersModule|{}serializersModule[0]
         final fun <get-serializersModule>(): kotlinx.serialization.modules/SerializersModule // dev.burnoo.kspoon.configuration/KspoonConfiguration.serializersModule.<get-serializersModule>|<get-serializersModule>(){}[0]
 }

--- a/kspoon/src/commonMain/kotlin/Kspoon.kt
+++ b/kspoon/src/commonMain/kotlin/Kspoon.kt
@@ -1,6 +1,5 @@
 package dev.burnoo.kspoon
 
-import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.select.Elements
 import dev.burnoo.kspoon.configuration.KspoonBuilder
 import dev.burnoo.kspoon.configuration.KspoonConfiguration
@@ -48,7 +47,7 @@ import kotlinx.serialization.serializer
  * """
  *
  * val kspoon = Kspoon {
- *     parse = { html -> parse(html, baseUri = "https://github.com/") }
+ *     parse = { html -> Ksoup.parse(html, baseUri = "https://github.com/") }
  *     coerceInputValues = true
  * }
  *
@@ -129,7 +128,7 @@ public sealed class Kspoon(
         if (deserializer.descriptor.kind is PrimitiveKind) {
             kspoonError("Parsing is not supported for primitive types. Use class instead")
         }
-        val document = configuration.parse(Ksoup, html)
+        val document = configuration.parse(html)
         val decoder = HtmlTreeDecoder(
             elements = Elements(document),
             configuration = configuration,

--- a/kspoon/src/commonMain/kotlin/configuration/KspoonBuilder.kt
+++ b/kspoon/src/commonMain/kotlin/configuration/KspoonBuilder.kt
@@ -1,7 +1,7 @@
 package dev.burnoo.kspoon.configuration
 
-import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.parser.Parser
 import dev.burnoo.kspoon.HtmlTextMode
 import dev.burnoo.kspoon.Kspoon
 import dev.burnoo.kspoon.annotation.Selector
@@ -21,7 +21,7 @@ import kotlinx.serialization.modules.SerializersModule
  */
 public class KspoonBuilder internal constructor(kspoon: Kspoon) {
     /**
-     * Specifies [Ksoup] function that is used for parsing. Allows to set up [Ksoup].
+     * Specifies parsing function. Allows to set up Ksoup or [Parser].
      *
      * Example:
      * ```
@@ -32,14 +32,14 @@ public class KspoonBuilder internal constructor(kspoon: Kspoon) {
      * )
      *
      * val kspoon = Kspoon {
-     *     parse = { html -> parse(html, baseUri = "https://github.com") }
+     *     parse = { html -> Ksoup.parse(html, baseUri = "https://github.com") }
      * }
      *
      * val url = kspoon.parse<Model>("""<a href="burnoo">Click</a>""").url
      * println(url) // prints "https://github.com/burnoo"
      * ```
      */
-    public var parse: Ksoup.(String) -> Document = kspoon.configuration.parse
+    public var parse: (String) -> Document = kspoon.configuration.parse
 
     /**
      * Specifies default [HtmlTextMode] that is used for parsing. Can be overridden by [Selector.textMode]

--- a/kspoon/src/commonMain/kotlin/configuration/KspoonConfiguration.kt
+++ b/kspoon/src/commonMain/kotlin/configuration/KspoonConfiguration.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.modules.SerializersModule
 
 @PublishedApi
 internal class KspoonConfiguration(
-    val parse: Ksoup.(html: String) -> Document = { parse(it) },
+    val parse: (html: String) -> Document = { html -> Ksoup.parse(html) },
     val defaultTextMode: HtmlTextMode = HtmlTextMode.Text,
     val coerceInputValues: Boolean = false,
     val serializersModule: SerializersModule = EmptySerializersModule(),

--- a/kspoon/src/commonTest/kotlin/KspoonConfigurationTest.kt
+++ b/kspoon/src/commonTest/kotlin/KspoonConfigurationTest.kt
@@ -1,5 +1,6 @@
 package dev.burnoo.kspoon
 
+import com.fleeksoft.ksoup.Ksoup
 import dev.burnoo.kspoon.annotation.Selector
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
@@ -31,7 +32,7 @@ class KspoonConfigurationTest {
             val url: String,
         )
         val kspoon = Kspoon {
-            parse = { parse(it, baseUri = "https://github.com") }
+            parse = { html -> Ksoup.parse(html, baseUri = "https://github.com") }
         }
 
         val text = kspoon.parse<Model>("""<a href="burnoo">Click</a>""")


### PR DESCRIPTION
Previous one was less readable in my opinion. Also updates Ktor and Retrofit docs with its usage.