### PR TITLE
Upgrade `:ksoup-lite` 0.2.0 to `:ksoup` 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ dependencies {
 ```
 
 This library uses
-the [ksoup-lite](https://github.com/fleeksoft/ksoup/?tab=readme-ov-file#ksoup-is-published-on-maven-central)
+the [lightweight](https://github.com/fleeksoft/ksoup/?tab=readme-ov-file#ksoup-is-published-on-maven-central)
 variant of Ksoup. If you plan to use other variants of the Ksoup library within the same project, you may need to
-replace `ksoup-lite` with
+replace `:ksoup` with
 your preferred variant by using
 Gradle's [dependency substitution](https://docs.gradle.org/current/userguide/resolution_rules.html#sec:variant_aware_substitutions).
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.0"
 kotlinxSerialization = "1.7.3"
-ksoup = "0.2.0"
+ksoup = "0.2.1"
 dokka = "2.0.0"
 logback = "1.5.15"
 binaryCompatibilityValidator = "0.17.0"
@@ -18,7 +18,7 @@ retrofit = "2.11.0"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
-ksoup-lite = { module = "com.fleeksoft.ksoup:ksoup-lite", version.ref = "ksoup" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 # Test dependencies

--- a/kspoon/build.gradle.kts
+++ b/kspoon/build.gradle.kts
@@ -54,7 +54,7 @@ apiValidation {
 tasks.withType<Test> { useJUnitPlatform() }
 
 dependencies {
-    commonMainApi(libs.ksoup.lite)
+    commonMainApi(libs.ksoup)
     commonMainImplementation(libs.kotlinx.serialization.core)
 
     commonTestImplementation(libs.kotlin.test)


### PR DESCRIPTION
Ksoup library changed artifacts names in `0.2.1` release. Lighweight varaint is now called `:ksoup` instead of `:ksoup-core`.

Here comes the update 